### PR TITLE
Add `-p` to `mkdir` when creating Gedit Plugins dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install jedi
 
 Instead of downloading you can just clone the project to your plugin path:
 ```
-$ mkdir ~/.local/share/gedit/plugins
+$ mkdir -p ~/.local/share/gedit/plugins
 $ cd ~/.local/share/gedit/plugins
 $ git clone https://github.com/isamert/gedi.git
 ```


### PR DESCRIPTION
if `~/.local/share/gedit` does not exist yet, as is the case of a new install, plain `mkdir ~/.local/share/gedit/plugins` will fail. `-p` (or `--parents`) will fix this, creating any required parents